### PR TITLE
feat: Add step-based model checkpoint saving

### DIFF
--- a/rag_retrieval/train/embedding/train_embedding.py
+++ b/rag_retrieval/train/embedding/train_embedding.py
@@ -73,6 +73,7 @@ def parse_args():
     parser.add_argument("--log_with", type=str, default='wandb', help='wandb,tensorboard')
     parser.add_argument("--log_interval", type=int, default=10)
     parser.add_argument("--eval_steps", type=int, default=None)
+    parser.add_argument("--save_steps", type=int, default=None)
 
     parser.add_argument('--use_mrl', action='store_true', help='if use mrl loss')
     parser.add_argument('--mrl_dims', type=str, help='list of mrl dims', default='128, 256, 512, 768, 1024, 1280, 1536, 1792')
@@ -203,6 +204,7 @@ def main():
         lr_scheduler=lr_scheduler,
         log_interval=args.log_interval * accelerator.gradient_state.num_steps,
         eval_steps=args.eval_steps * accelerator.gradient_state.num_steps if args.eval_steps else args.eval_steps,
+        save_steps=args.save_steps * accelerator.gradient_state.num_steps if args.save_steps else args.save_steps,
         save_on_epoch_end=args.save_on_epoch_end,
         tokenizer=tokenizer,
     )


### PR DESCRIPTION
1. **Purpose**
This PR aims to add the functionality of saving model checkpoints at each specified training step. Previously, model checkpoints were only saved at the end of each epoch, which might lead to the loss of important model states during training. By saving checkpoints at steps, we can preserve the model's state more frequently and recover from potential interruptions more easily.
2. **Main Changes**
    - Added `save_steps` parameter in the `__init__` method of the `Trainer` class to specify the step interval for model checkpoint saving.
    - Modified the training loop to call the model saving function and save the model checkpoint when the current step is a multiple of `save_steps`.
3. **Testing**
    - **Functionality Test**: Tested locally. The step - based model checkpoint saving works correctly, and the model checkpoints are saved as expected.
    - **Compatibility Test**: Ensured the modified code is compatible with the existing codebase without introducing new errors.
4. **Notes**
Adjust the `save_steps` parameter according to actual needs to balance the frequency of checkpoint saving and training efficiency.

### Review Suggestions
Reviewers are suggested to focus on:
- The correctness of the code logic.
- Consistency with the existing code style and architecture.
- Performance impact due to more frequent checkpoint saving.