### PR TITLE
Add All-Gather in Triplet Mode for Enhanced Negative Sample Sampling

### DIFF
--- a/rag_retrieval/train/embedding/model.py
+++ b/rag_retrieval/train/embedding/model.py
@@ -148,21 +148,21 @@ class Embedding(nn.Module):
                 rank = accelerator.process_index
                 world_size = accelerator.num_processes
                 B_total = B * world_size
-                all_doc_embedding = accelerator.gather(
+                all_neg_doc_embedding = accelerator.gather(
                     neg_doc_embeddings)  # [B_total * neg_nums, D]
                 if self.use_mrl:
                     loss = torch.tensor(0.0, device=query_embeddings.device)
                     for num_dim in self.mrl_dims:
-                        query_emb, pos_doc_emb, all_doc_emb = query_embeddings[..., :num_dim], pos_doc_embeddings[..., :num_dim], all_doc_embedding[...,
+                        query_emb, pos_doc_emb, all_neg_doc_emb = query_embeddings[..., :num_dim], pos_doc_embeddings[..., :num_dim], all_neg_doc_embedding[...,
                                                                                                                                                     :num_dim]
                         cur_loss, cur_accuracy = self.triplet_inbatch_softmax_loss(
-                            query_emb, pos_doc_emb, all_doc_emb, require_acc=True)
+                            query_emb, pos_doc_emb, all_neg_doc_emb, require_acc=True)
                         loss += cur_loss
                         res_dict['accuracy_dim_{}'.format(num_dim)] = cur_accuracy
                     loss = loss / len(self.mrl_dims)
                 else:
                     loss, accuracy = self.triplet_inbatch_softmax_loss(
-                        query_embeddings, pos_doc_embeddings, all_doc_emb, require_acc=True)
+                        query_embeddings, pos_doc_embeddings, all_neg_doc_embedding, require_acc=True)
                     res_dict['accuracy'] = accuracy
                 res_dict['loss'] = loss
             


### PR DESCRIPTION
Add All-Gather in Triplet Mode for More Negative Samples
1. Purpose
This PR adds all-gather to triplet mode to sample more negative samples by leveraging distributed representations, improving feature discriminability.
2. Main Changes
Implemented all-gather in triplet loss pipeline to collect embeddings across processes.
Updated negative sampling logic to use gathered embeddings for larger sample pool.
Optimized loss function to handle expanded negatives efficiently.