### PR TITLE
fix(reranker): use tokenizer `__call__` instead of removed batch_encode_plus (#119)

### DIFF
--- a/rag_retrieval/train/reranker/model_bert.py
+++ b/rag_retrieval/train/reranker/model_bert.py
@@ -76,7 +76,10 @@ class CrossEncoder(nn.Module):
             new_sentences_pairs.append([new_query, new_document])
         assert len(new_sentences_pairs) == len(sentences_pairs)
 
-        tokens = self.tokenizer.batch_encode_plus(
+        # `batch_encode_plus` was removed from transformers tokenizers; the
+        # supported API for a batched call is the tokenizer's __call__
+        # (which automatically picks the batched path when given a list).
+        tokens = self.tokenizer(
             new_sentences_pairs,
             add_special_tokens=True,
             padding="longest",


### PR DESCRIPTION
Closes #119.

`rag_retrieval/train/reranker/model_bert.py:79` calls `self.tokenizer.batch_encode_plus(...)`. Recent `transformers` releases removed `batch_encode_plus` from the tokenizer public surface — the supported batched-call API is the tokenizer's `__call__`, which automatically picks the batched path when given a list of sequence pairs.

Switch the call site to `self.tokenizer(...)`. All keyword arguments (`add_special_tokens`, `padding`, `max_length`, `truncation`, `return_tensors`) are accepted unchanged by the new API, so the returned `BatchEncoding` is identical.
