### PR TITLE
Fix broken star history charts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ During the development process, we borrowed or based on the implementation of th
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=NovaSearch-Team/RAG-Retrieval&type=Date)](https://star-history.com/#NovaSearch-Team/RAG-Retrieval&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=NovaSearch-Team/RAG-Retrieval&type=Date)](https://star-history.dera.page/#NovaSearch-Team/RAG-Retrieval&Date)
 
 # License
 RAG-Retrieval is licensed under the [MIT License](https://github.com/NLPJCL/RAG-Retrieval/blob/master/LICENSE). 

--- a/README_zh.md
+++ b/README_zh.md
@@ -139,7 +139,7 @@ RAG-Retrieval开发了一个轻量级的python库[rag-retrieval](https://pypi.or
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=NLPJCL/RAG-Retrieval&type=Date)](https://star-history.com/#NLPJCL/RAG-Retrieval&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=NLPJCL/RAG-Retrieval&type=Date)](https://star-history.dera.page/#NLPJCL/RAG-Retrieval&Date)
 
 # License
 RAG-Retrieval is licensed under the [MIT License](https://github.com/NLPJCL/RAG-Retrieval/blob/master/LICENSE). 


### PR DESCRIPTION
The star history charts in the README files are currently broken and no longer render, caused by GitHub stargazer API restrictions on the previous provider. This change points the charts at a working source so they display correctly again.